### PR TITLE
Unify resource manager and bootloader naming

### DIFF
--- a/COMMON/source/baro_MPL3115A2_Role.cpp
+++ b/COMMON/source/baro_MPL3115A2_Role.cpp
@@ -67,11 +67,11 @@ DeviceStatus Baro_MPL3115A2_Role::start(UAVCAN::Node& node)
   using HR = HWResource;
   
 #ifdef     BOARD_ENAC_MINICANv4
-  if (not boardResource.try_acquire(HR::PA15, HR::PB07, HR::I2C_1)) {
+  if (not boardResource.tryAcquire(HR::PA15, HR::PB07, HR::I2C_1)) {
     return DeviceStatus(DeviceStatus::RESOURCE, DeviceStatus::CONFLICT);
   }
 #elifdef BOARD_ENAC_MICROCANv2
-  if (not boardResource.try_acquire(HR::I2C_1)) {
+  if (not boardResource.tryAcquire(HR::I2C_1)) {
     return DeviceStatus(DeviceStatus::RESOURCE, DeviceStatus::CONFLICT);
   }
   DynPin::setScenario(DynPin::Scenario::I2C);

--- a/COMMON/source/escDshotRole.cpp
+++ b/COMMON/source/escDshotRole.cpp
@@ -43,13 +43,13 @@ DeviceStatus EscDshot::start(UAVCAN::Node& /*node*/)
 
   
   // use timer
-  if (not boardResource.try_acquire(HR::TIM_1, HR::TIM_7)) {
+  if (not boardResource.tryAcquire(HR::TIM_1, HR::TIM_7)) {
     return DeviceStatus(DeviceStatus::RESOURCE, DeviceStatus::CONFLICT);
   }
 
   // only the pins that are actually in use depending on role.pwm.num_servos
   for (uint8_t channel=0; channel < numChannels; channel++) {
-    if (not boardResource.try_acquire(static_cast<HR>(std::to_underlying(HR::PA08) + channel))) {
+    if (not boardResource.tryAcquire(static_cast<HR>(std::to_underlying(HR::PA08) + channel))) {
       return DeviceStatus(DeviceStatus::RESOURCE, DeviceStatus::CONFLICT);
     }
   }

--- a/COMMON/source/ressourceManager.hpp
+++ b/COMMON/source/ressourceManager.hpp
@@ -50,7 +50,7 @@ public:
   }
 
   template<std::same_as<HWResource>... Args>
-  bool try_acquire(Args... resources) {
+  bool tryAcquire(Args... resources) {
     UNSIGNED req_mask = mask(resources...);
     if ((m_bitmap & req_mask) != 0) return false;
     m_bitmap |= req_mask;
@@ -63,15 +63,15 @@ public:
     m_bitmap &= ~rel_mask;
   }
 
-  bool is_allocated(HWResource res) const {
+  bool isAllocated(HWResource res) const {
     return (m_bitmap & shiftbit(res)) != 0;
   }
 
-  void reset_all() {
+  void resetAll() {
     m_bitmap = 0;
   }
 
-  int count_allocated() const {
+  int countAllocated() const {
     return std::popcount(m_bitmap);
   }
 };

--- a/COMMON/source/sbusTunnelRole.cpp
+++ b/COMMON/source/sbusTunnelRole.cpp
@@ -31,7 +31,7 @@ DeviceStatus SbusTunnel::start(UAVCAN::Node& _node)
   DeviceStatus status(DeviceStatus::SBUS_TUNNEL);
   
   // use serial2 rx
-  if (not boardResource.try_acquire(HR::USART_2, HR::PB04)) {
+  if (not boardResource.tryAcquire(HR::USART_2, HR::PB04)) {
     return DeviceStatus(DeviceStatus::RESOURCE, DeviceStatus::CONFLICT);
   }
   enabledChannels = decode_channel_mask(PARAM_CGET("role.tunnel.sbus.active_channels"));

--- a/COMMON/source/servoPwm.cpp
+++ b/COMMON/source/servoPwm.cpp
@@ -66,14 +66,14 @@ DeviceStatus ServoPWM::start()
   pwmServoCfg.period = servoTickFreq / servoPwmFreq;
 
   // use timer
-  if (not boardResource.try_acquire(HR::TIM_1)) {
+  if (not boardResource.tryAcquire(HR::TIM_1)) {
     return DeviceStatus(DeviceStatus::RESOURCE, DeviceStatus::CONFLICT);
   }
 
   // only the pins that are actually in use depending on role.pwm.num_servos
   for (uint8_t channel=0; channel < numServos; channel++) {
     pwmServoCfg.channels[channel] = {.mode = PWM_OUTPUT_ACTIVE_HIGH, .callback = NULL};
-    if (not boardResource.try_acquire(static_cast<HR>(std::to_underlying(HR::PA08) + channel))) {
+    if (not boardResource.tryAcquire(static_cast<HR>(std::to_underlying(HR::PA08) + channel))) {
       return DeviceStatus(DeviceStatus::RESOURCE, DeviceStatus::CONFLICT);
     }
   }

--- a/COMMON/source/servoSmart.cpp
+++ b/COMMON/source/servoSmart.cpp
@@ -37,7 +37,7 @@ DeviceStatus ServoSmart::start()
   DynPin::setScenario(DynPin::Scenario::USART);
 #endif
 
-  if (not boardResource.try_acquire(HR::USART_2, HR::PB03)) {
+  if (not boardResource.tryAcquire(HR::USART_2, HR::PB03)) {
     return DeviceStatus(DeviceStatus::RESOURCE, DeviceStatus::CONFLICT);
   }
   

--- a/COMMON/source/telemetryTunnelRole.cpp
+++ b/COMMON/source/telemetryTunnelRole.cpp
@@ -225,7 +225,7 @@ DeviceStatus TelemetryTunnel::start(UAVCAN::Node&)
   
   
   // use serial2 tx/rx
-  if (not boardResource.try_acquire(HR::USART_2, HR::PB03, HR::PB04)) {
+  if (not boardResource.tryAcquire(HR::USART_2, HR::PB03, HR::PB04)) {
     return DeviceStatus(DeviceStatus::RESOURCE, DeviceStatus::CONFLICT);
   }
   

--- a/bootloader/source/main.cpp
+++ b/bootloader/source/main.cpp
@@ -42,7 +42,7 @@ namespace {
    * starts in a clean environment, preventing potential conflicts from
    * peripherals configured by the bootloader.
    */
-  void disable_and_reset_all_stm32g4_rcc_peripherals(void);
+  void disableAndResetAllStm32g4RccPeripherals(void);
 
   /**
    * @brief Jumps to the given address and restarts the CPU.
@@ -333,7 +333,7 @@ namespace {
     
     
     
-    void disable_and_reset_all_stm32g4_rcc_peripherals(void) {
+    void disableAndResetAllStm32g4RccPeripherals(void) {
       // --- AHB1 ---
       RCC->AHB1ENR &= ~(RCC_AHB1ENR_DMA1EN |
 		      RCC_AHB1ENR_DMA2EN |
@@ -483,7 +483,7 @@ namespace {
     __set_MSP( (uint32_t) (((uint32_t *) address)[0]) ); 
     __DSB();
     __ISB();
-    disable_and_reset_all_stm32g4_rcc_peripherals();
+    disableAndResetAllStm32g4RccPeripherals();
     ( (void (*)(void)) (((uint32_t *) address)[1]) )();
     __builtin_unreachable(); 
   }


### PR DESCRIPTION
## Summary
- rename HWResourceManager APIs to camelCase
- update all calling code
- rename `disable_and_reset_all_stm32g4_rcc_peripherals` in bootloader to camelCase

## Testing
- `make -k` *(fails: File::Slurp module missing and ChibiOS paths not found)*

------
https://chatgpt.com/codex/tasks/task_e_68872f0379e8832c92d2127086554f8a